### PR TITLE
Update with WP version and script to resize before uploading

### DIFF
--- a/canvas-image-resize.php
+++ b/canvas-image-resize.php
@@ -121,7 +121,7 @@ class CanvasImageResize
     protected function initPluginPage()
     {
         add_action('plugins_loaded', array($this, 'addTextDomain'));
-        add_action('admin_init', array($this, 'initOptionsPage'));
+        add_action('admin_init', array($this, 'initAdmin'));
         add_action('admin_menu', array($this, 'addOptionsPage'));
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'addPluginPage'));
     }
@@ -189,11 +189,11 @@ class CanvasImageResize
     }
 
     /**
-     * Render the options page
+     * Register the options and additional script
      *
      * @return void
      */
-    public function initOptionsPage()
+    public function initAdmin()
     {
         // add the possibility to add settings
         register_setting(static::OPTIONS_PAGE_NAME, $this->getOptionsName());
@@ -231,6 +231,10 @@ class CanvasImageResize
             static::OPTIONS_PAGE_NAME,
             $sectionName
         );
+
+        // Add additional script which resizes images before checking
+        // the image size
+        wp_enqueue_script('plupload-additional', plugin_dir_url( __FILE__ ) . 'script.js', array('plupload'), null, true);
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: sippsolutions
 Donate link: https://www.paypal.me/sippert
 Tags: image, upload, processing, canvas
 Requires at least: 3.3.2
-Tested up to: 4.4.2
-Stable tag: 1.0.0
+Tested up to: 5.6
+Stable tag: 1.0.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,8 @@ Re-sizes images right inside the browser BEFORE uploading them.
 
 == Description ==
 
-If you host your site in a very poor environment, WordPress may fail uploading large images as the process of creating the different sizes and thumbnails takes a large amount of CPU usage.
+If you host your site in a poor environment, WordPress may fail uploading large images as the process of creating the different sizes and thumbnails takes a large amount of CPU usage.
+
 With this Plugin the images are simply resized to a maximum dimension (of for example 1600 x 1600 pixels) right in your browser before uploading them.
 The nice side effect is that unnecessary big images are resized to a fine size to still provide a usable, qualitative image.
 
@@ -28,6 +29,9 @@ Logo credits: Picture graphic by Flaticon from Freepik.
 1. The settings page.
 
 == Changelog ==
+
+= 1.0.1 =
+* Translated the plugin in German.
 
 = 1.0 =
 * Implemented the functionality on media gallery page.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,78 @@
+/**
+ * Modify plupload to resize images before checking the image size
+ */
+
+
+if(window['plupload']) {
+
+	// Copied from plupload source code as this function is inaccessible
+	function resizeImage(blob, params, cb) {
+		var img = new mOxie.Image(); // o in source code = mOxie in global
+
+		try {
+			img.onload = function() {
+				// no manipulation required if...
+				if (params.width > this.width &&
+					params.height > this.height &&
+					params.quality === undef &&
+					params.preserve_headers &&
+					!params.crop
+				) {
+					this.destroy();
+					return cb(blob);
+				}
+				// otherwise downsize
+				img.downsize(params.width, params.height, params.crop, params.preserve_headers);
+			};
+
+			img.onresize = function() {
+				cb(this.getAsBlob(blob.type, params.quality));
+				this.destroy();
+			};
+
+			img.onerror = function() {
+				cb(blob);
+			};
+
+			img.load(blob);
+		} catch(ex) {
+			console.log(ex);
+			cb(blob);
+		}
+	}
+
+	// Bit of a hack to actually modify plupload inline
+	let oldInit = plupload.Uploader;
+	plupload.Uploader = function() {
+
+		oldInit.apply(this, arguments);
+		
+		// Hook into pluploader here
+		if(this['addFile']) {
+			let oldAddFile = this.addFile;
+			// Override addFile to resize the image first!
+			this.addFile = function(files, fileName) {
+				let self = this;
+
+				// Always assume arrays are being processed
+				if(mOxie.typeOf(files) !== 'array') {
+					files = [files];
+				}
+
+				mOxie.each(files, function(file){
+					// Resize them using pluploader resizer code
+					resizeImage.call(this, file, self.settings.resize, function(resizedBlob) {
+						// Now pass the new resized file down into the original function which should
+						// allow most large images to upload without issues
+						oldAddFile.call(self, resizedBlob, fileName);
+					});
+				});
+				
+			};
+		}
+
+	}
+	plupload.Uploader.prototype = oldInit.prototype;
+
+
+}


### PR DESCRIPTION
Hi, I've recently come across your plugin and I love it.

This MR:

* Updates this GitHub with the latest code I found on WordPress.org
* Adds a Javascript to force the plupload component to resize images before checking their size - This allows higher than PHP max filesize images appear to upload